### PR TITLE
Fixed testedfiles in tests so the tests pass

### DIFF
--- a/testsuite/Modules/tests/SambaTrustDom.ycp
+++ b/testsuite/Modules/tests/SambaTrustDom.ycp
@@ -1,5 +1,5 @@
 {
-    //testedfiles: SambaTrustDom.ycp
+    //testedfiles: SambaTrustDom.pm
 
     include "testsuite.ycp";
 

--- a/testsuite/YaPI/tests/YaPI-AddSAM-2.ycp
+++ b/testsuite/YaPI/tests/YaPI-AddSAM-2.ycp
@@ -3,7 +3,7 @@
 // test for YaPI::Samba::AddSAM()
 // $Id$
 
-    // testedfiles: Samba.pm
+    // testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-AddSAM.ycp
+++ b/testsuite/YaPI/tests/YaPI-AddSAM.ycp
@@ -3,7 +3,7 @@
 // test for YaPI::Samba::AddSAM()
 // $Id$
 
-    // testedfiles: Samba.pm
+    // testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-AddShare.ycp
+++ b/testsuite/YaPI/tests/YaPI-AddShare.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::AddShare()
 // $Id$
-// testedfiles: SambaServer.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-DeleteSAM-2.ycp
+++ b/testsuite/YaPI/tests/YaPI-DeleteSAM-2.ycp
@@ -1,6 +1,6 @@
 {
 
-    // testedfiles: Samba.pm
+// testedfiles: SambaConfig.pm
 
 // test for YaPI::Samba::DeleteSAM()
 // $Id$

--- a/testsuite/YaPI/tests/YaPI-DeleteSAM-3.ycp
+++ b/testsuite/YaPI/tests/YaPI-DeleteSAM-3.ycp
@@ -3,7 +3,7 @@
 // test for YaPI::Samba::DeleteSAM()
 // $Id$
 
-    // testedfiles: Samba.pm
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-DeleteSAM.ycp
+++ b/testsuite/YaPI/tests/YaPI-DeleteSAM.ycp
@@ -3,7 +3,7 @@
 // test for YaPI::Samba::DeleteSAM()
 // $Id$
 
-    // testedfiles: Samba.pm
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-DeleteShare-2.ycp
+++ b/testsuite/YaPI/tests/YaPI-DeleteShare-2.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::DeleteShare()
 // $Id$
-// testedfiles: SambaServer.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-DeleteShare.ycp
+++ b/testsuite/YaPI/tests/YaPI-DeleteShare.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::DeleteShare()
 // $Id$
-// testedfiles: SambaServer.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EditDefaultSAM.ycp
+++ b/testsuite/YaPI/tests/YaPI-EditDefaultSAM.ycp
@@ -3,7 +3,7 @@
 // test for YaPI::Samba::EditDefaultSAM()
 // $Id$
 
-    // testedfiles: Samba.pm
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EditSAMConfiguration.ycp
+++ b/testsuite/YaPI/tests/YaPI-EditSAMConfiguration.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EditSAMConfiguration()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EditServerAsBDC.ycp
+++ b/testsuite/YaPI/tests/YaPI-EditServerAsBDC.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EditServerAsBDC()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaRole.pm SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EditServerAsPDC.ycp
+++ b/testsuite/YaPI/tests/YaPI-EditServerAsPDC.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EditServerAsPDC()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaRole.pm SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EditServerAsStandalone.ycp
+++ b/testsuite/YaPI/tests/YaPI-EditServerAsStandalone.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EditServerAsStandalone()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EditServerDescription.ycp
+++ b/testsuite/YaPI/tests/YaPI-EditServerDescription.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EditServerDescription()
 // $Id$
-// testedfiles: SambaServer.ycp 
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EditShare.ycp
+++ b/testsuite/YaPI/tests/YaPI-EditShare.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EditShare()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EnableHomes.ycp
+++ b/testsuite/YaPI/tests/YaPI-EnableHomes.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EnableHomes()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EnableNetlogon.ycp
+++ b/testsuite/YaPI/tests/YaPI-EnableNetlogon.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EnableNetlogon()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EnableShare-2.ycp
+++ b/testsuite/YaPI/tests/YaPI-EnableShare-2.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EnablePrinters()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 

--- a/testsuite/YaPI/tests/YaPI-EnableShare.ycp
+++ b/testsuite/YaPI/tests/YaPI-EnableShare.ycp
@@ -2,7 +2,7 @@
 
 // test for YaPI::Samba::EnablePrinters()
 // $Id$
-// testedfiles: Samba.ycp Service.ycp SambaServer.ycp Ldap.ycp
+// testedfiles: SambaConfig.pm
 
     import "SambaConfig";
 


### PR DESCRIPTION
after fixing perl-bindings to report the source lines correctly
(see https://github.com/yast/yast-ruby-bindings/issues/43)
