### PR TITLE
Fix duplicated 'Firewall Settings' string on Startup tab bnc#884058

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jul 6 11:45:53 UTC 2014 - noel.power@suse.com
+- Fix duplicated 'Firewall Settings' string on Startup tab; (bnc#884058)
+- 3.1.9
+
+-------------------------------------------------------------------
 Tue May  6 05:34:49 UTC 2014 - mfilka@suse.com
 
 - Adapted testsuite to last changes in Service module.

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        3.1.8
+Version:        3.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/samba-server/dialogs.rb
+++ b/src/include/samba-server/dialogs.rb
@@ -1247,7 +1247,7 @@ module Yast
                 VSpacing(1),
                 "SERVICE START",
                 VSpacing(1),
-                Frame(_("Firewall Settings"), "FIREWALL"),
+                "FIREWALL",
                 VStretch()
               )
             ),


### PR DESCRIPTION
Seems there is an unecessary Frame with extra title (the title is the
repeated text) here (which encloses the custom FIREWALL widget).The
FIREWALL widget on its own already contains the text that is repeated.
