### PR TITLE
pass osVersion and osName (and empty osServicePack) to join command

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 13 11:54:52 UTC 2015 - nopower@suse.com
+
+- When joining domain provide osName & osVer arguments to "net ads join"
+  (bnc#873922).
+- 3.1.12
+
+-------------------------------------------------------------------
 Wed Nov 12 13:11:35 UTC 2014 - nopower@suse.com
 
 - Squash "Possible precedence issue with control flow operator

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -38,7 +38,7 @@ Requires:	yast2-ldap >= 3.1.2
 Requires:	yast2-perl-bindings
 Requires:	yast2-network
 # samba-client/routines.rb
-Requires:	yast2-samba-client >= 3.1.2
+Requires:	yast2-samba-client >= 3.1.15
 Requires:	yast2-users
 
 # bnc #386473, recommend yast2-samba-server when installaing these packages

--- a/src/include/samba-server/dialogs.rb
+++ b/src/include/samba-server/dialogs.rb
@@ -56,6 +56,7 @@ module Yast
       Yast.import "CWMTab"
       Yast.import "CWMServiceStart"
       Yast.import "CWMFirewallInterfaces"
+      Yast.import "OSRelease"
 
       Yast.include include_target, "samba-server/helps.rb"
       Yast.include include_target, "samba-server/dialogs-items.rb"
@@ -1738,13 +1739,17 @@ module Yast
       return :skip if ret == :skip
       return :cancel if ret != :ok
 
+      relname = OSRelease.ReleaseName
+      relver = OSRelease.ReleaseVersion
       # try to join the domain
       error = SambaNetJoin.Join(
         workgroup,
         Builtins.tolower(role),
         user,
         passwd,
-        ""
+        "",
+        relname,
+        relver
       )
       if error != nil
         Popup.Error(error)


### PR DESCRIPTION
The yast2-samab-client changes to ensure osVersion and osName are
passed to 'net ads join' have changed the SambaJoinNet:Join api so we
need accompaning changes to adjust to the new api