### PR TITLE
Fixed string comparison. (bsc#1029528)

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 16 15:51:19 UTC 2017 - kanderssen@suse.com
+
+- Fix string comparisons in SambaBackendLDAP.pm and YaPI/Samba.pm
+  (bsc#1029528)
+- 3.2.0
+
+-------------------------------------------------------------------
 Tue Jun  7 11:08:42 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        3.1.16
+Version:        3.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SambaPrinters.pm
+++ b/src/modules/SambaPrinters.pm
@@ -276,7 +276,7 @@ removeShare() {
 enableShare() {
     ...
     // [printers] is coupled with "load printers"
-    if( name == "printers" ) 
+    if( name eq "printers" ) 
 	global_config["load printers"] = on;
 
     ...

--- a/src/modules/YaPI/Samba.pm
+++ b/src/modules/YaPI/Samba.pm
@@ -182,7 +182,7 @@ sub DetermineRole {
     my $self = shift;
     SambaConfig->Read();
     my $role = SambaRole->GetRole();
-    $role = "STANDALONE" if $role == "MEMBER";
+    $role = "STANDALONE" if $role eq "MEMBER";
     return lc $role;
 }
 

--- a/testsuite/YaPI/tests/YaPI-DetermineRole2.rb
+++ b/testsuite/YaPI/tests/YaPI-DetermineRole2.rb
@@ -17,7 +17,7 @@ module Yast
           "global" => {
             "workgroup"        => "Test",
             "domain master"    => "yes",
-            "security"         => "user",
+            "security"         => "share",
             "preferred master" => "yes",
             "domain logons"    => "yes",
             "local master"     => "yes"

--- a/testsuite/YaPI/tests/YaPI-DetermineRole3.out
+++ b/testsuite/YaPI/tests/YaPI-DetermineRole3.out
@@ -1,1 +1,1 @@
-Return	standalone
+Return	bdc

--- a/testsuite/YaPI/tests/YaPI-DetermineRole3.rb
+++ b/testsuite/YaPI/tests/YaPI-DetermineRole3.rb
@@ -17,7 +17,7 @@ module Yast
           "global" => {
             "workgroup"        => "Test",
             "domain master"    => "no",
-            "security"         => "user",
+            "security"         => "domain",
             "preferred master" => "yes",
             "domain logons"    => "yes",
             "local master"     => "yes"


### PR DESCRIPTION
Fix string comparisons in SambaBackendLDAP.pm and YaPI/Samba.pm and also some tests that were passing just because of the used operator.