### PR TITLE
Use firewalld samba service definition

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar  1 12:40:05 UTC 2018 - knut.anderssen@suse.com
+
+- Use firewalld samba service definition (bsc#1083456)
+- 4.0.1
+
+-------------------------------------------------------------------
 Mon Feb  5 10:06:46 UTC 2018 - knut.anderssen@suse.com
 
 - SuSEFirewall2 replaced by firewalld (fate#323460)

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/samba-server/dialogs.rb
+++ b/src/include/samba-server/dialogs.rb
@@ -1282,11 +1282,7 @@ module Yast
         # BNC #247344, BNC #541958 (comment #18)
         "FIREWALL"             => CWMFirewallInterfaces.CreateOpenFirewallWidget(
           {
-            "services"        => [
-              "samba-server",
-              "netbios-server",
-              "samba-client"
-            ],
+            "services"        => ["samba"],
             "display_details" => true
           }
         ),

--- a/src/include/samba-server/dialogs.rb
+++ b/src/include/samba-server/dialogs.rb
@@ -1282,6 +1282,7 @@ module Yast
         # BNC #247344, BNC #541958 (comment #18)
         "FIREWALL"             => CWMFirewallInterfaces.CreateOpenFirewallWidget(
           {
+            # Firewalld default service definition
             "services"        => ["samba"],
             "display_details" => true
           }


### PR DESCRIPTION
In this case we can use the firewalld samba service definition so does not make sense to ship any definition with samba package at all.

- https://bugzilla.suse.com/show_bug.cgi?id=1083456