### PR TITLE
Fix Dockerfile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config.sub
 configure
 configure.ac
 depcomp
+doc/autodocs
 install-sh
 *.pot
 libtool
@@ -26,6 +27,7 @@ Makefile.am.common
 *.bz2
 .dep
 tmp.*
+.yardoc/
 *.log
 /doc/autodocs
 /testsuite/Modules/

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM yastdevel/ruby:sle12-sp5
 
+RUN zypper --non-interactive in --no-recommends \
+  perl-Crypt-SmbHash \
+  yast2-samba-client
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
Just to make [Travis](https://travis-ci.org/yast/yast-samba-server/builds/561035789) happy again :)

* Install required packages in the Docker image to make possible the successful execution of the new [Perl syntax check](https://github.com/yast/docker-yast-ruby/commit/7dd9c8cab22fa7f7d516d9664c091f19e06673be)
* Add the Yard options file
  > Borrowed from yast/yast-nfs-server#35
* Fix .gitignore
