### PR TITLE
Fix old testsuite failing

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 11 14:56:40 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Fild failing old testsuite (bsc#1155923)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:38:03 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Nov 11 14:56:40 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
-- Fild failing old testsuite (bsc#1155923)
+- Fix failing old testsuite (bsc#1155923)
 - 4.2.1
 
 -------------------------------------------------------------------

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            https://github.com/yast/yast-samba-server
 Summary:        YaST2 - Samba Server Configuration

--- a/testsuite/YaPI/tests/YaPI-GetServiceStatus.out
+++ b/testsuite/YaPI/tests/YaPI-GetServiceStatus.out
@@ -1,4 +1,5 @@
 Return	Disabled service
+Read	.target.tmpdir "/tmp"
 Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show smb.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"", "stdout":""]
 Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password is-enabled smb.service " $["exit":0, "stderr":"", "stdout":""]
 Return	0


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1155923
- https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:F/yast2-samba-server/standard/x86_64


Replace https://github.com/yast/yast-samba-server/pull/69 just fixing the old testsuite that is currently failing. 

Let the removal of unused code when we really plan to refactor the module or more work expected