### PR TITLE
Fix YaPI-GetServiceStatus failing old testsuite

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 28 14:35:11 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix failing Samba.GetServiceStatus old testsuite forcing and
+  import of 'Directory' (bsc#1155923)
+- 4.2.2
+
+-------------------------------------------------------------------
 Mon Nov 11 14:56:40 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix failing old testsuite (bsc#1155923)

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Url:            https://github.com/yast/yast-samba-server
 Summary:        YaST2 - Samba Server Configuration

--- a/testsuite/YaPI/tests/YaPI-GetServiceStatus.out
+++ b/testsuite/YaPI/tests/YaPI-GetServiceStatus.out
@@ -1,5 +1,4 @@
 Return	Disabled service
-Read	.target.tmpdir "/tmp"
 Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password show smb.service  --property=Id  --property=MainPID  --property=Description  --property=LoadState  --property=ActiveState  --property=SubState  --property=UnitFileState  --property=FragmentPath  --property=CanReload " $["exit":0, "stderr":"", "stdout":""]
 Execute	.target.bash_output " LANG=C TERM=dumb COLUMNS=1024 /usr/bin/systemctl --no-legend --no-pager --no-ask-password is-enabled smb.service " $["exit":0, "stderr":"", "stdout":""]
 Return	0

--- a/testsuite/YaPI/tests/YaPI-GetServiceStatus.rb
+++ b/testsuite/YaPI/tests/YaPI-GetServiceStatus.rb
@@ -7,6 +7,10 @@ module Yast
       # $Id$
 
       Yast.import "SambaConfig"
+      # Import "Directory" just for avoid its initialization which reads the
+      # ".target.tmpdir". This change was consequence of bsc#1151291, which added
+      # an import of "Systemd" in Y2Network::Systemd::Unit
+      Yast.import "Directory"
 
       Yast.include self, "testsuite.rb"
       Yast.include self, "tests-common.rb"


### PR DESCRIPTION
## Problem

The `YaPI-GetServiceStatus` test started to fail because of this [PR](https://github.com/yast/yast-yast2/pull/972) where basically an import of 'Systemd' was added.

`Systemd` imports `FileUtils` which imports `Popup` which imports `Directory`.

- https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:G/yast2-samba-server/standard/x86_64

## Solution

The issue could be solved in yast2 moving the `Systemd` import to the method which uses it, returning without importing in case of `Mode.testsuite`, but, as it is consequence of `YaPI` and a old testsuite, will just do an earlier import in the failing test. If we see that it affects other tests in other modules then it will be done also in yast2
