### PR TITLE
Ensure nmbd is restarted following nmbstatus lookup

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 18 09:55:16 UTC 2019 - Petr Pavlu <petr.pavlu@suse.com>
+
+- Ensure nmbd is restarted following nmbstatus lookup (bsc#1158916)
+- 4.2.3
+
+-------------------------------------------------------------------
 Thu Nov 28 14:35:11 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix failing Samba.GetServiceStatus old testsuite forcing and

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Url:            https://github.com/yast/yast-samba-server
 Summary:        YaST2 - Samba Server Configuration

--- a/src/modules/SambaServer.pm
+++ b/src/modules/SambaServer.pm
@@ -224,6 +224,9 @@ sub Read {
     
     $GlobalsConfigured = $self->Configured();
 
+    # ensure nmbd is restarted if stopped for lookup
+    SambaNmbLookup->checkNmbstatus() unless Mode->test();
+
     y2milestone("Service:". (SambaService->GetServiceAutoStart() ? "Enabled" : "Disabled"));
     y2milestone("Role:". SambaRole->GetRoleName());
 


### PR DESCRIPTION
When the YaST samba-server module is started, it stops the nmb service to run nmbstatus but does not always start is again as it should.

The following happens:
* Code in `yast-samba-server/src/modules/SambaServer.pm` calls `SambaNmbLookup->Start()` from `yast-samba-client/src/modules/SambaNmbLookup.pm`.
* `SambaNmbLookup.pm` stops the nmb service and asynchronously starts nmbstatus.
* No call is made to `SambaNmbLookup->checkNmbstatus()` to ensure nmbstatus completed and nmbd can be started again.

This is [bsc#1158916](https://bugzilla.suse.com/show_bug.cgi?id=1158916). Issue [bsc#895319](https://bugzilla.suse.com/show_bug.cgi?id=895319) was a similar problem but in yast-samba-client and got fixed by https://github.com/yast/yast-samba-client/pull/32/. The patch here takes the same approach.