### PR TITLE
Propose 'restart' as the default service widget action when running and no user connected

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Mar  5 13:59:38 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Propose to restart samba services by default when writing the
+  configuration with services already running. Reload is still used
+  if some user is connected to the samba server (bsc#1165638)
+- 4.1.4
+
+-------------------------------------------------------------------
 Wed Dec 12 12:47:46 UTC 2018 - Josef Reidinger <jreidinger@suse.com>
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/samba-server/complex.rb
+++ b/src/include/samba-server/complex.rb
@@ -87,7 +87,7 @@ module Yast
       # If there some connected users, SAMBA is running and should be running
       # also after the Write() operation and the Progress was turned on before
       # Writing SAMBA conf
-      switch_to_reload = connected_users? && switch_to_reload? && ProgressStatus()
+      switch_to_reload = need_to_restart? && connected_users? && ProgressStatus()
 
       ret = save_status(switch_to_reload)
 
@@ -106,20 +106,12 @@ module Yast
       ret ? :next : :abort
     end
 
-    # Convenience method to check whether a reload should be used instead of a
-    # restart
-    #
-    # @return [Boolean] true if a reload is prefered; false otherwise
-    def switch_to_reload?
-      need_to_restart? && connected_users?
-    end
-
     # Convenience method to check whether a restart or reload should be used
     # after writing the configuration
     #
-    # @return [Boolean] true if a reload is prefered; false otherwise
+    # @return [Boolean] true if the service is running; false otherwise
     def need_to_restart?
-      SambaService.GetServiceRunning && SambaService.GetServiceAutoStart
+      SambaService.GetServiceRunning
     end
 
     # Convenience method to check whether there are users connected to samba

--- a/src/include/samba-server/complex.rb
+++ b/src/include/samba-server/complex.rb
@@ -111,7 +111,8 @@ module Yast
     #
     # @return [Boolean] true if the service is running; false otherwise
     def need_to_restart?
-      SambaService.GetServiceRunning
+      # could be partialy active. i.e: smb is running and nmb is not
+      services.currently_active?
     end
 
     # Convenience method to check whether there are users connected to samba

--- a/src/include/samba-server/complex.rb
+++ b/src/include/samba-server/complex.rb
@@ -87,13 +87,7 @@ module Yast
       # If there some connected users, SAMBA is running and should be running
       # also after the Write() operation and the Progress was turned on before
       # Writing SAMBA conf
-      connected_users = SambaService.ConnectedUsers.count
-      Builtins.y2milestone("Number of connected users: %1", connected_users)
-
-      switch_to_reload = connected_users > 0 &&
-        SambaService.GetServiceRunning &&
-        SambaService.GetServiceAutoStart &&
-        ProgressStatus()
+      switch_to_reload = connected_users? && switch_to_reload? && ProgressStatus()
 
       ret = save_status(switch_to_reload)
 
@@ -110,6 +104,33 @@ module Yast
         )
       end
       ret ? :next : :abort
+    end
+
+    # Convenience method to check whether a reload should be used instead of a
+    # restart
+    #
+    # @return [Boolean] true if a reload is prefered; false otherwise
+    def switch_to_reload?
+      need_to_restart? && connected_users?
+    end
+
+    # Convenience method to check whether a restart or reload should be used
+    # after writing the configuration
+    #
+    # @return [Boolean] true if a reload is prefered; false otherwise
+    def need_to_restart?
+      SambaService.GetServiceRunning && SambaService.GetServiceAutoStart
+    end
+
+    # Convenience method to check whether there are users connected to samba
+    # service or not
+    #
+    # @return [Boolean] true if some user is connected to the service; false
+    #   otherwise
+    def connected_users?
+      connected_users = SambaService.ConnectedUsers.count
+      Builtins.y2milestone("Number of connected users: %1", connected_users)
+      connected_users > 0
     end
 
     # Saves service status (start mode and starts/stops the service)

--- a/src/include/samba-server/dialogs.rb
+++ b/src/include/samba-server/dialogs.rb
@@ -102,9 +102,7 @@ module Yast
     def service_widget
       return @service_widget if @service_widget
       @service_widget = ::CWM::ServiceWidget.new(services)
-      if services.currently_active? && !connected_users
-        @service_widget.default_action = :restart
-      end
+      @service_widget.default_action = :restart if need_to_restart? && !connected_users
       @service_widget
     end
 

--- a/src/include/samba-server/dialogs.rb
+++ b/src/include/samba-server/dialogs.rb
@@ -100,7 +100,12 @@ module Yast
     #
     # @return [::CWM::ServiceWidget]
     def service_widget
-      @service_widget ||= ::CWM::ServiceWidget.new(services)
+      return @service_widget if @service_widget
+      @service_widget = ::CWM::ServiceWidget.new(services)
+      if services.currently_active? && !connected_users
+        @service_widget.default_action = :restart
+      end
+      @service_widget
     end
 
     # routines

--- a/src/modules/SambaService.pm
+++ b/src/modules/SambaService.pm
@@ -145,7 +145,7 @@ sub StartStopNow {
     my ($self, $on) = @_;
     my $error = 0;
 
-    # Zero connected users -> restart, einther -> reload
+    # Zero connected users -> restart, either -> reload
     my $connected_users = $self->ConnectedUsers();
     my $nr_connected_users = scalar(@$connected_users);
 

--- a/test/dialog_complex_test.rb
+++ b/test/dialog_complex_test.rb
@@ -42,17 +42,18 @@ describe "SambaServerComplexInclude" do
     allow(Yast2::SystemService).to receive(:find).with(anything).and_return(service)
     allow(Yast2::CompoundService).to receive(:new).and_return(services)
     allow(services).to receive(:action).and_return(action)
+    allow(services).to receive(:currently_active?).and_return(service_running)
   end
 
   let(:service) { instance_double("Yast2::SystemService", save: true, is_a?: true) }
   let(:services) { instance_double("Yast2::CompoundService", save: true) }
+  let(:service_running) { false }
   let(:action) { :start }
 
   describe "#WriteDialog" do
     subject(:samba) { TestComplexDialog.new }
 
     let(:connected_users) { ["john", "jane"] }
-    let(:service_running) { false }
     let(:service_on_boot) { false }
 
     let(:auto) { false }


### PR DESCRIPTION
## Problem

When the new service widget was [introduced](https://trello.com/c/uAe4i9Ru/107-5-fate319428-allow-socket-activation-widget), the default action when writing the modified configuration was to `keep the current state`, that basically means **do not touch the service**.

That was not the default action in **SLE-12** for some of the modules that use the new service widget, at least it is not the case of this module.

For that reason, in previous sprint it was agreed to change the default action, using `reload` (when supported) or `restart` when the service was **active** and `keep_the_current_state` when it was **inactive**. (see https://github.com/yast/yast-yast2/pull/1001)

Samba service supports reload and thus, it is proposed by default, but, it should be chosen by default only if there is some user connected, if not, we should use restart as it was in **SLE-12**

- https://trello.com/c/0iBBEqsF/1635-8-check-all-listed-modules-whether-the-new-servicewidget-default-action-is-the-correct-one
- https://bugzilla.suse.com/show_bug.cgi?id=1165638

## Solution

- Propose **restart** as the default service widget action in case that the service is running and there are no users connected to samba service.