### PR TITLE
Fix popup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v2
 
+    # workaround issue with missing useradd
+    - name: Install useradd
+      run: zypper --non-interactive in shadow
+
     - name: Install Dependencies
       run: rake build_dependencies:install
 
@@ -42,6 +46,10 @@ jobs:
 
     - name: Git Checkout
       uses: actions/checkout@v2
+
+    # workaround issue with missing useradd
+    - name: Install useradd
+      run: zypper --non-interactive in shadow
 
     - name: Install Dependencies
       run: rake build_dependencies:install

--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 17 20:55:59 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.4
+
+-------------------------------------------------------------------
 Tue Aug 11 11:54:32 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(samba-server) into the spec file

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 Url:            https://github.com/yast/yast-samba-server
 Summary:        YaST2 - Samba Server Configuration

--- a/test/dialog_complex_test.rb
+++ b/test/dialog_complex_test.rb
@@ -171,6 +171,7 @@ describe "SambaServerComplexInclude" do
             context "with connected users" do
               it "changes action to :reload" do
                 expect(services).to receive(:reload)
+                allow(Yast::Report).to receive(:Message)
 
                 samba.WriteDialog
               end


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.