### PR TITLE
SambaServer: module PackageSystem is deprecated, use Package instead

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 27 11:27:19 UTC 2022 - Noel Power <nopower@suse.com>
+
+- Replace use of PackageSystem with Package to avoid core dumps;
+  (bsc#1195182).
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Url:            https://github.com/yast/yast-samba-server
 Summary:        YaST2 - Samba Server Configuration

--- a/src/modules/SambaServer.pm
+++ b/src/modules/SambaServer.pm
@@ -49,7 +49,7 @@ YaST::YCP::Import("Summary");
 YaST::YCP::Import("Progress");
 #HELPME: YaST::YCP::Import("Directory");
 YaST::YCP::Import("FirewalldWrapper");
-YaST::YCP::Import("PackageSystem");
+YaST::YCP::Import("Package");
 
 YaST::YCP::Import("SambaRole");
 YaST::YCP::Import("SambaConfig");
@@ -105,9 +105,9 @@ sub GetModified {
 BEGIN{ $TYPEINFO{GetModified} = ["function", "boolean"] }
 sub CheckAndInstallBasePackages {
   # installed_required_packages? or installed_packages_gplv3? or install_packages!
-  PackageSystem->InstalledAll($RequiredPackages) ||
-    PackageSystem->InstalledAll($RequiredPackages_gplv3) ||
-      PackageSystem->CheckAndInstallPackagesInteractive($RequiredPackages) ||
+  Package->InstalledAll($RequiredPackages) ||
+    Package->InstalledAll($RequiredPackages_gplv3) ||
+      Package->CheckAndInstallPackagesInteractive($RequiredPackages) ||
         return 0;
   return 1;
 }
@@ -119,7 +119,7 @@ sub CheckNeedToInstallCupsPackages {
     unless ((lc $printing eq "cups") and SambaConfig->ShareExists("printers") and SambaConfig->ShareEnabled("printers")) {
         return 0;
     }
-    if (PackageSystem->InstalledAll($CupsPackages)) {
+    if (Package->InstalledAll($CupsPackages)) {
         return 0;
     }
 
@@ -188,7 +188,7 @@ sub Read {
                 SambaConfig->ShareDisable("printers");
                 SambaConfig->ShareSetModified("printers");
             } else {
-                PackageSystem->CheckAndInstallPackagesInteractive($CupsPackages) or return 0
+                Package->CheckAndInstallPackagesInteractive($CupsPackages) or return 0
             }
         }
     }
@@ -299,7 +299,7 @@ sub Write {
 #    # check, if we need samba-pdb package
 #    my %backends = map {/:/;$`||$_,1} split " ", SambaConfig->GlobalGetStr("passdb backend", "");
 #    if($backends{mysql}) {
-#	PackageSystem->CheckAndInstallPackagesInteractive(["samba-pdb"]) or return 0;
+#	Package->CheckAndInstallPackagesInteractive(["samba-pdb"]) or return 0;
 #    }
 
     y2milestone ("Writing WINS Host Resolution=", Samba->GetHostsResolution());


### PR DESCRIPTION
On most recent tw & sle15sp4 using PackageSystem causes core dumps
sees this is a result of efforts with bsc#1194886

Signed-off-by: Noel Power <noel.power@suse.com>