### PR TITLE
Remove libsmbclient-devel BuildRequires in favor of pkgconfig(smbclient)

### DIFF
--- a/package/yast2-samba-server.changes
+++ b/package/yast2-samba-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  2 12:18:23 UTC 2022 - Samuel Cabrero <scabrero@suse.de>
+
+- Remove libsmbclient-devel BuildRequires in favor of
+  pkgconfig(smbclient); (jsc#SLE-20577);
+- 4.4.2
+
+-------------------------------------------------------------------
 Thu Jan 27 11:27:19 UTC 2022 - Noel Power <nopower@suse.com>
 
 - Replace use of PackageSystem with Package to avoid core dumps;

--- a/package/yast2-samba-server.spec
+++ b/package/yast2-samba-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-server
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Url:            https://github.com/yast/yast-samba-server
 Summary:        YaST2 - Samba Server Configuration
@@ -27,7 +27,7 @@ License:        GPL-2.0-only
 Source0:        %{name}-%{version}.tar.bz2
 
 # Service.Active
-BuildRequires:  libsmbclient-devel
+BuildRequires:  pkgconfig(smbclient)
 BuildRequires:  perl-Crypt-SmbHash
 BuildRequires:  perl-X500-DN
 BuildRequires:  update-desktop-files


### PR DESCRIPTION
Signed-off-by: Samuel Cabrero <scabrero@suse.de>